### PR TITLE
Acceleration time calculation for Fermi 2nd

### DIFF
--- a/sections/acceleration.tex
+++ b/sections/acceleration.tex
@@ -393,7 +393,7 @@ The total cycle time is the sum of the times spent in the downstream and upstrea
 t_{\rm c, i} = \frac{\lambda_i}{\langle v_{x,i} \rangle} = \frac{\lambda_i}{-\int_0^{\pi/2} v_i \cos \theta d\cos\theta} = \frac{\lambda_i}{v_i / 2} \sim \frac{2\lambda_i}{c}$}:
 %
 \begin{equation}
-t_{\text{cycle}} = \frac{2\lambda_1}{c} + \frac{2\lambda_2}{c} = \frac{4}{c} \left(\frac{D_1}{u_1} + \frac{D_2}{u_2}\right)
+t_{\text{cycle}} = \frac{\lambda_1^2}{D_1} + \frac{\lambda_2^2}{D_2} = \left(\frac{D_1}{u_1^2} + \frac{D_2}{u_2^2}\right)
 \end{equation}
 
 The characteristic acceleration timescale is then:


### PR DESCRIPTION
(page 54 in the PDF)

This is not (yet) an edit, but a question.

From eq. (3.24) and a footnote it seems like we're assuming ballistic propagation across the length $\lambda_{1,2}$. This is not obvious, as these lengths are not obtained as mean free paths, but from a balance between diffusion and advection, yet particles should still cover them in diffusive regime.

I tried to repeat the calculation with this assumption (see proposed edit) and it effectively adds 2 orders of magnitude, since in denominator $c$ is replaced with $u_{1,2}$. This brings the result at 1 GeV from 1 to 100 kyrs.

I'm not sure what to make of it, and if this logic is sound or not.

Another question I had related to this calculation is about downstream diffusion length. It doesn't seem to appear naturally in Fokker-Planck equation solution (at least stationary), as advection and diffusion do not counteract each other. Is there a deep reason to introduce it here, or is it just for convenience of order of magnitude estimation?